### PR TITLE
fix : change condition to comply with sh (resolve issue #147)

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -3,8 +3,8 @@
 set -xe
 
 # check if cargo is installed
-if ! command -v cargo &> /dev/null; then
-  echo -e "\033[1;31m[ERROR]\033[0m Cargo is not installed. Please install Rust from https://rustup.rs."
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "\033[1;31m[ERROR]\033[0m Cargo is not installed. Please install Rust from https://rustup.rs."
   exit 1
 fi
 


### PR DESCRIPTION
Change from >&1 to 2>&1 to make the condition work with the correct reference.
Delete the -e option of the echo, not existing in sh